### PR TITLE
Do not always link to /usr/lib/wine

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -60,7 +60,6 @@ wineasio_dll_LDFLAGS  = -shared \
 			-m$(M) \
 			-mnocygwin \
 			$(wineasio_dll_MODULE:%=%.spec) \
-			-L/usr/lib/wine \
 			-L/usr/lib$(M)/wine \
 			-L/usr/lib/$(ARCH)-linux-gnu/wine \
 			-L/usr/lib/$(ARCH)-linux-gnu/wine-development \


### PR DESCRIPTION
Doing that makes linking stage fail when compiling for 32bit because it
will link against both /usr/lib/wine and /usr/lib32/wine