### PR TITLE
Fix build for newer versions of wine-staging

### DIFF
--- a/main.c
+++ b/main.c
@@ -23,6 +23,7 @@
 #include "winuser.h"
 #include "winreg.h"
 #include "objbase.h"
+#include "unknwn.h"
 
 #ifdef DEBUG
 #include "wine/debug.h"


### PR DESCRIPTION
Newer versions of wine-staging seem to have moved the definition of `IID_IClassFactory` into `unknwn.h` instead. Without this commit I get the following build error:

~~~~
winegcc build32/asio.c.o build32/main.c.o build32/regsvr.c.o -shared -m32 -mnocygwin wineasio.dll.spec -L/usr/lib32/wine -L/usr/lib/wine -L/usr/lib/i386-linux-gnu -L/usr/lib/i386-linux-gnu/wine -L/usr/lib/i386-linux-gnu/wine-development -L/opt/wine-stable/lib -L/opt/wine-stable/lib/wine -L/opt/wine-stable/lib32 -L/opt/wine-stable/lib32/wine -L/opt/wine-staging/lib -L/opt/wine-staging/lib/wine -L/opt/wine-staging/lib32 -L/opt/wine-staging/lib32/wine -ljack  \
	-lodbc32 -lole32 -lwinmm -luuid -o build32/wineasio32.dll.so
/usr/bin/ld: build32/main.c.o: in function `DllGetClassObject':
main.c:(.text+0xeb): undefined reference to `IID_IClassFactory'
/usr/bin/ld: build32/main.c.o: relocation R_386_GOTOFF against undefined hidden symbol `IID_IClassFactory' can not be used when making a shared object
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
winegcc: /usr/bin/gcc failed
make[1]: *** [Makefile.mk:111: build32/wineasio32.dll.so] Error 2
make[1]: Leaving directory '/home/infinity0/ext/git/wineasio'
make: *** [Makefile:17: 32] Error 2
2
~~~~

Using this version of wine-staging:

~~~~
 *** 8.19~trixie-1 990
        990 https://dl.winehq.org/wine-builds/debian trixie/main amd64 Packages
        100 /var/lib/dpkg/status
~~~~

With this PR the build works.