### PR TITLE
fix 32-bit DLL location for multiarch Wine

### DIFF
--- a/wineasio-register
+++ b/wineasio-register
@@ -34,7 +34,11 @@ u64=(
 for u in ${u32[@]}; do
     w=$(echo ${u} | sed -e 's|/i386-unix/wineasio32.dll.so|/i386-windows/wineasio32.dll|g')
     if [ -e "${u}" ] && [ -e "${w}" ]; then
-        cp -v "${w}" "${WINEPREFIX}/drive_c/windows/system32"
+        if command -v wine64 > /dev/null && [ -d "${WINEPREFIX}/drive_c/windows/syswow64" ]; then
+            cp -v "${w}" "${WINEPREFIX}/drive_c/windows/syswow64"
+        else
+            cp -v "${w}" "${WINEPREFIX}/drive_c/windows/system32"
+        fi
         regsvr32 "${u}"
         break
     fi


### PR DESCRIPTION
The *wineasio-register* script always copies the 32-bit WineASIO DLL into `${WINEPREFIX}/drive_c/windows/system32`. In a multiarch Wine config, this results in broken WineASIO for 32-bit apps. My update to the script checks for a multiarch install and if found, copies the 32-bit DLL into `${WINEPREFIX}/drive_c/windows/syswow64` instead.

Fixes issue #76