### PR TITLE
Show outcome of wineasio-register to stderr

### DIFF
--- a/wineasio-register
+++ b/wineasio-register
@@ -1,14 +1,14 @@
 #!/bin/bash
-
-# exit if any command fails
-set -e
+me=wineasio-register
+# exit if any command fails (commented so project-specific errors can be shown via echo)
+# set -e
 
 # read WINEPREFIX from environment, with fallback if unset
 WINEPREFIX=${WINEPREFIX:=~/.wine}
 
 # make sure the WINEPREFIX directory exists
 if [ ! -d "${WINEPREFIX}" ]; then
-    wineboot -u
+    wineboot -u || exit $?
 fi
 
 # define possible locations for wineasio DLLs
@@ -31,17 +31,31 @@ u64=(
 )
 
 # try to register 32bit DLL
+code=0
+status32="not found"
 for u in ${u32[@]}; do
     w=$(echo ${u} | sed -e 's|/i386-unix/wineasio32.dll.so|/i386-windows/wineasio32.dll|g')
     if [ -e "${u}" ] && [ -e "${w}" ]; then
         cp -v "${w}" "${WINEPREFIX}/drive_c/windows/system32"
         regsvr32 "${u}"
+        code=$?
+        if [ $code -eq 0 ]; then
+            status32="registered"
+        else
+            status32="registration failed"
+        fi
         break
     fi
 done
+>&2 echo "[$me] 32-bit dll.so $status32"
+if [ $code -ne 0 ]; then exit $code; fi
+
+status64="not found"
 
 # only continue past this point if wine64 command is available and prefix supports 64bit
 if [ ! -d "${WINEPREFIX}/drive_c/windows/syswow64" ]; then
+    status64="is not applicable (no syswow64 was found)"
+    >&2 echo "[$me] 64-bit dll.so $status64"
     exit 0
 fi
 
@@ -50,6 +64,8 @@ if command -v wine64 >/dev/null 2>&1; then
 elif [ -e /usr/lib/wine/wine64 ]; then
     WINE64="/usr/lib/wine/wine64"
 else
+    status64="is not applicable (no wine64 was found)"
+    >&2 echo "[$me] 64-bit dll.so $status64"
     exit 0
 fi
 
@@ -59,6 +75,14 @@ for u in ${u64[@]}; do
     if [ -e "${u}" ] && [ -e "${w}" ]; then
         cp -v "${w}" "${WINEPREFIX}/drive_c/windows/system32"
         ${WINE64} regsvr32 "${u}"
+        code=$?
+        if [ $code -eq 0 ]; then
+            status64="registered"
+        else
+            status64="registration failed"
+        fi
         break
     fi
 done
+>&2 echo "[$me] 64-bit dll.so $status64"
+exit $code


### PR DESCRIPTION
If dll.so files were never found, an error is shown instead of no output.