### PR TITLE
Cleanup Makefile.mk

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -56,7 +56,6 @@ wineasio_dll_C_SRCS   = asio.c \
 			regsvr.c
 wineasio_dll_LDFLAGS  = -shared \
 			-m$(M) \
-			-mnocygwin \
 			wineasio.dll.spec \
 			-L/usr/lib$(M)/wine \
 			-L/usr/lib/wine \

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -18,6 +18,7 @@ PREFIX                = /usr
 SRCDIR                = .
 DLLS                  = $(wineasio_dll_MODULE) $(wineasio_dll_MODULE).so
 
+PKG_CONFIG_PATH ?= /usr/lib$(M)/pkgconfig
 ### Tools
 
 CC        = gcc
@@ -29,7 +30,7 @@ WINECC    = winegcc
 CEXTRA                = -m$(M) -D_REENTRANT -fPIC -Wall -pipe
 CEXTRA               += -fno-strict-aliasing -Wdeclaration-after-statement -Wwrite-strings -Wpointer-arith
 CEXTRA               += -Werror=implicit-function-declaration
-CEXTRA               += $(shell pkg-config --cflags jack)
+CEXTRA               += $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --cflags jack)
 RCEXTRA               =
 INCLUDE_PATH          = -I. -Irtaudio/include
 INCLUDE_PATH         += -I$(PREFIX)/include/wine
@@ -40,7 +41,7 @@ INCLUDE_PATH         += -I/opt/wine-stable/include
 INCLUDE_PATH         += -I/opt/wine-stable/include/wine/windows
 INCLUDE_PATH         += -I/opt/wine-staging/include
 INCLUDE_PATH         += -I/opt/wine-staging/include/wine/windows
-LIBRARIES             = $(shell pkg-config --libs jack)
+LIBRARIES             = $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --libs jack)
 
 # Debug or Release
 ifeq ($(DEBUG),true)

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -44,7 +44,7 @@ LIBRARIES             = $(shell pkg-config --libs jack)
 
 # Debug or Release
 ifeq ($(DEBUG),true)
-CEXTRA               += -O0 -DDEBUG -g -D__WINESRC__
+CEXTRA               += -O0 -DDEBUG -g -D__WINESRC__ -v
 else
 CEXTRA               += -O2 -DNDEBUG -fvisibility=hidden
 endif

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -14,11 +14,12 @@ endif
 
 wineasio_dll_MODULE   = wineasio$(M).dll
 
-PREFIX                = /usr
-SRCDIR                = .
 DLLS                  = $(wineasio_dll_MODULE) $(wineasio_dll_MODULE).so
 
 PKG_CONFIG_PATH ?= /usr/lib$(M)/pkgconfig
+WINE_INCLUDE_PATH		?= /usr/include/wine
+WINE_LIBDIR ?= /usr/lib$(M)/wine
+
 ### Tools
 
 CC        = gcc
@@ -33,14 +34,8 @@ CEXTRA               += -Werror=implicit-function-declaration
 CEXTRA               += $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --cflags jack)
 RCEXTRA               =
 INCLUDE_PATH          = -I. -Irtaudio/include
-INCLUDE_PATH         += -I$(PREFIX)/include/wine
-INCLUDE_PATH         += -I$(PREFIX)/include/wine/windows
-INCLUDE_PATH         += -I$(PREFIX)/include/wine-development
-INCLUDE_PATH         += -I$(PREFIX)/include/wine-development/wine/windows
-INCLUDE_PATH         += -I/opt/wine-stable/include
-INCLUDE_PATH         += -I/opt/wine-stable/include/wine/windows
-INCLUDE_PATH         += -I/opt/wine-staging/include
-INCLUDE_PATH         += -I/opt/wine-staging/include/wine/windows
+INCLUDE_PATH         += -I$(WINE_INCLUDE_PATH)
+INCLUDE_PATH         += -I$(WINE_INCLUDE_PATH)/windows
 LIBRARIES             = $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --libs jack)
 
 # Debug or Release
@@ -59,17 +54,9 @@ wineasio_dll_LDFLAGS  = -shared \
 			-m$(M) \
 			wineasio.dll.spec \
 			-L/usr/lib$(M)/wine \
-			-L/usr/lib/wine \
-			-L/usr/lib/$(ARCH)-linux-gnu/wine \
-			-L/usr/lib/$(ARCH)-linux-gnu/wine-development \
-			-L/opt/wine-stable/lib \
-			-L/opt/wine-stable/lib/wine \
-			-L/opt/wine-stable/lib$(M) \
-			-L/opt/wine-stable/lib$(M)/wine \
-			-L/opt/wine-staging/lib \
-			-L/opt/wine-staging/lib/wine \
-			-L/opt/wine-staging/lib$(M) \
-			-L/opt/wine-staging/lib$(M)/wine
+			-L$(WINE_LIBDIR) \
+			-L$(WINE_LIBDIR)/$(ARCH)-unix \
+			-L$(WINE_LIBDIR)/$(ARCH)-windows
 wineasio_dll_DLLS     = odbc32 \
 			ole32 \
 			winmm


### PR DESCRIPTION
- Remove useless -mnocygwin flag. Fixes https://github.com/wineasio/wineasio/issues/115
- Be more verbose when debugging.
- Introduce a few configurable variables to be customized by developers, packagers and maintainers from outside Makefile.mk, which allows us to cleanup the -I and -L paths multiplication.