### PR TITLE
Add GitHub workflow for Ubuntu 24.04 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Configure APT
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -qy \
+            wine64-tools \
+            libwine-dev \
+            libwine-dev:i386 \
+            gcc-multilib
+      - name: 64-bit Build
+        run:  make 64
+      - name: 32-bit Build
+        run:  make 32
+      - uses: actions/upload-artifact@v4
+        with:
+          name: WineASIO 64-bit
+          path: |
+            build64/wineasio64.dll
+            build64/wineasio64.dll.so
+      - uses: actions/upload-artifact@v4
+        with:
+          name: WineASIO 32-bit
+          path: |
+            build32/wineasio32.dll
+            build32/wineasio32.dll.so

--- a/Makefile.mk
+++ b/Makefile.mk
@@ -43,6 +43,7 @@ else
 INCLUDE_PATH         += \
 			-I$(PREFIX)/include/wine \
 			-I$(PREFIX)/include/wine/windows \
+			-I$(PREFIX)/include/wine/wine/windows \
 			-I$(PREFIX)/include/wine-development \
 			-I$(PREFIX)/include/wine-development/wine/windows \
 			-I/opt/wine-stable/include \


### PR DESCRIPTION
Fixes compilation on current Ubuntu LTS and provides an automatic build script for Github which also archives artefacts for 32 and 64 bit builds